### PR TITLE
fix(jell): fix equality bug and lambda application bug 

### DIFF
--- a/src/user/bin/jell.rs
+++ b/src/user/bin/jell.rs
@@ -723,7 +723,10 @@ impl Evaluator {
                     }
                     for (name, val) in zip(vars, rest) {
                         let_args.push(Expr::Symbol(name));
-                        let_args.push(self.evaluate(val.clone(), env)?)
+                        let_args.push(Expr::List(Rc::new(vec![
+                            Expr::Symbol("quote".into()),
+                            self.evaluate(val.clone(), env)?,
+                        ])));
                     }
                     let mut args = vec![Expr::Vector(Rc::new(let_args.clone()))];
                     args.append(&mut body.clone());

--- a/src/user/bin/jell.rs
+++ b/src/user/bin/jell.rs
@@ -304,8 +304,8 @@ impl Lexer {
         }
         self.read_char();
         let x = &self.input[pos..self.pos - 1];
-        match x.iter().collect::<String>().parse() {
-            Ok(f) => Ok(f),
+        match x.iter().collect::<String>().parse::<String>() {
+            Ok(f) => Ok(unescape(f.as_str())),
             Err(_) => Err(Error::LexicalError("failed to read string".into())),
         }
     }
@@ -2042,4 +2042,12 @@ fn evaluator_test() {
             println!("{:?}", result)
         }
     }
+}
+
+fn unescape(s: &str) -> String {
+    s.replace("\\n", "\n")
+        .replace("\\r", "\r")
+        .replace("\\t", "\t")
+        .replace("\\\\", "\\")
+        .replace("\\'", "\'")
 }

--- a/src/user/bin/jell.rs
+++ b/src/user/bin/jell.rs
@@ -21,7 +21,7 @@ use ulib::io::Read;
 use ulib::stdio::stdin;
 use ulib::{env, eprint, eprintln, print, println};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 enum Expr {
     Symbol(String),
     Keyword(String),
@@ -35,6 +35,23 @@ enum Expr {
     List(Rc<Vec<Expr>>),
     Vector(Rc<Vec<Expr>>),
     Set(Rc<Vec<Expr>>),
+}
+
+impl PartialEq for Expr {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, &other) {
+            (Expr::Keyword(a), Expr::Keyword(b)) => a == b,
+            (Expr::String(a), Expr::String(b)) => a == b,
+            (Expr::Int(a), Expr::Int(b)) => a == b,
+            (Expr::Float(a), Expr::Float(b)) => a == b,
+            (Expr::Bool(a), Expr::Bool(b)) => a == b,
+            (Expr::Nil, Expr::Nil) => true,
+            (Expr::List(a), Expr::List(b)) => a == b,
+            (Expr::Vector(a), Expr::Vector(b)) => a == b,
+            (Expr::Set(a), Expr::Set(b)) => a == b,
+            _ => true,
+        }
+    }
 }
 
 impl Display for Expr {
@@ -496,18 +513,19 @@ fn repl() {
 
         if paren_stack.len() == 0 {
             input = "".to_string();
-            let mut parser = Parser::new(tokens);
-            match parser.parse() {
-                Ok(expr) => match evaluator.evaluate(expr, &mut env) {
-                    Ok(expr) => println!("{}", expr),
-                    Err(err) => eprintln!("error: {:?}", err),
-                },
-                Err(err) => panic!(),
+            if tokens.len() > 0 {
+                let mut parser = Parser::new(tokens);
+                match parser.parse() {
+                    Ok(expr) => match evaluator.evaluate(expr, &mut env) {
+                        Ok(expr) => println!("{}", expr),
+                        Err(err) => eprintln!("error: {:?}", err),
+                    },
+                    Err(err) => panic!(),
+                }
+                tokens = vec![];
+                println!("")
             }
-            tokens = vec![];
         }
-        input = "".to_string();
-        println!("")
     }
 }
 
@@ -696,6 +714,13 @@ impl Evaluator {
                 Expr::Keyword(_) => todo!(),
                 Expr::Lambda(vars, body, inner_env) => {
                     let mut let_args: Vec<Expr> = vec![];
+                    if vars.len() != rest.len() {
+                        return Err(Error::RuntimeError(format!(
+                            "function takes {} arguments but got {} arguments",
+                            vars.len(),
+                            rest.len()
+                        )));
+                    }
                     for (name, val) in zip(vars, rest) {
                         let_args.push(Expr::Symbol(name));
                         let_args.push(self.evaluate(val.clone(), env)?)


### PR DESCRIPTION
# Summary of this PR
This PR will fix equality function bug and lambda application bug.
- `=` will now return a valid boolean for a given values (derived `PartialEq` did not meet the requirement.)
- Arguments given to a lambda expression were unintentionally evaluated twice. This caused the code like `(append '(1 2 3) '(4 5 6))` to fail, because `(1 2 3)` will be treated as lambda application.