### PR TITLE
fix: use rustc_align attribute to align functions

### DIFF
--- a/src/kernel/kernelvec.rs
+++ b/src/kernel/kernelvec.rs
@@ -3,7 +3,7 @@ use core::arch::naked_asm;
 // interrupts and exceptions while in supervisor mode come here.
 // push all registers, call kerneltrap(), restorem return.
 #[unsafe(naked)]
-#[repr(align(16))]
+#[rustc_align(16)]
 #[no_mangle]
 pub unsafe extern "C" fn kernelvec() -> ! {
     naked_asm!(
@@ -82,7 +82,7 @@ pub unsafe extern "C" fn kernelvec() -> ! {
 }
 
 #[unsafe(naked)]
-#[repr(align(16))] // if miss this alignment, a load access fault will occur.
+#[rustc_align(16)] // if miss this alignment, a load access fault will occur.
 #[no_mangle]
 pub unsafe extern "C" fn timervec() -> ! {
     // start.rs has set up the memory that mscratch points to:

--- a/src/kernel/swtch.rs
+++ b/src/kernel/swtch.rs
@@ -2,7 +2,7 @@ use crate::proc::Context;
 use core::arch::naked_asm;
 
 #[no_mangle]
-#[repr(align(16))]
+#[rustc_align(16)]
 #[unsafe(naked)]
 pub unsafe extern "C" fn swtch(old: &mut Context, new: &Context) {
     naked_asm!(

--- a/src/kernel/trampoline.rs
+++ b/src/kernel/trampoline.rs
@@ -18,7 +18,7 @@ extern "C" {
 #[link_section = "trampsec"]
 #[unsafe(naked)]
 #[no_mangle]
-#[repr(align(16))]
+#[rustc_align(16)]
 pub unsafe extern "C" fn uservec() -> ! {
     // trap.rs sets stvec to point here, so
     // traps from user space start here,
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn uservec() -> ! {
 #[link_section = "trampsec"]
 #[unsafe(naked)]
 #[no_mangle]
-#[repr(align(16))]
+#[rustc_align(16)]
 pub unsafe extern "C" fn userret(pagetable: usize) -> ! {
     // userret(TRAPFLAME, pagetable)
     // called by usertrap_ret() in trap.rs to


### PR DESCRIPTION
`cargo build` fails on `rustc 1.91.0-nightly (f2824da98 2025-08-28)` (current version as of this date) with errors of the following kind:
```
error: `#[repr(align(...))]` is not supported on functions
 --> src/kernel/kernelvec.rs:6:8
  |
6 | #[repr(align(16))]
  |        ^^^^^^^^^
  |
help: use `#[rustc_align(...)]` instead
 --> src/kernel/kernelvec.rs:6:8
  |
6 | #[repr(align(16))]
  |        ^^^^^^^^^
  ```
  
This is because the `#[align(..)]` attribute was renamed to `#[rustc_align(..)]` in the recent nightly versions. The fix is even suggested by the compiler itself. This PR applies the fix to all affected places.